### PR TITLE
Dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,15 +10,23 @@ Description: This package contains the learnR tutorials for the Psychology
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
-Suggests: 
-    learnr
 Imports: 
+    learnr
     gradethis (>= 0.1.0.9004),
     dplyr,
     palmerpenguins,
-    magrittr
+    magrittr,
+    tibble,
+    readr,
+    tidyr,
+    purrr,
+    here,
+    red (>= 0.1.0),
+    blue (>= 0.1.0)
 Remotes: 
-    rstudio-education/gradethis
+    rstudio-education/gradethis,
+    ljcolling/red,
+    ljcolling/blue
+RoxygenNote: 7.1.1
 Depends: 
     R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    learnr
     gradethis (>= 0.1.0.9004),
     dplyr,
     palmerpenguins,
@@ -22,7 +21,8 @@ Imports:
     purrr,
     here,
     red (>= 0.1.0),
-    blue (>= 0.1.0)
+    blue (>= 0.1.0),
+    learnr
 Remotes: 
     rstudio-education/gradethis,
     ljcolling/red,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     gradethis (>= 0.1.0.9004),
-    dplyr,
     palmerpenguins,
     magrittr,
     tibble,
@@ -21,8 +20,7 @@ Imports:
     purrr,
     here,
     red (>= 0.1.0),
-    blue (>= 0.1.0),
-    learnr
+    blue (>= 0.1.0)
 Remotes: 
     rstudio-education/gradethis,
     ljcolling/red,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     gradethis (>= 0.1.0.9004),
+    dplyr,
     palmerpenguins,
-    magrittr,
     tibble,
     readr,
     tidyr,


### PR DESCRIPTION
Fixed and added dependencies

-     gradethis (>= 0.1.0.9004),
-     dplyr,
-     palmerpenguins,
-     tibble,
-     readr,
-     tidyr,
-     purrr,
-     here,
-     red (>= 0.1.0),
-     blue (>= 0.1.0)

learnr is no longer a dependency and must be installed first. 